### PR TITLE
Slackメッセージの取得機能の追加

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -62,7 +62,8 @@ class MessagesController < ApplicationController
 
     observed_members.each do |channel, members|
       member_ids = members.map { |m| m.slack_account.account_id }
-      messages_response = slack_client.fetch_channel_members_messages(channel.channel_id, member_ids)
+      from = Message.channel_messages(channel).latest_slack_timestamp
+      messages_response = slack_client.fetch_channel_members_messages(channel.channel_id, member_ids, from:)
 
       ChannelMember.create_messages(messages_response, channel)
     end

--- a/app/models/channel_member.rb
+++ b/app/models/channel_member.rb
@@ -15,4 +15,16 @@ class ChannelMember < ApplicationRecord
   validates :slack_account_id, presence: true
 
   default_scope -> { kept }
+
+  class << self
+    def create_messages(messages_response, channel)
+      messages_response.each do |message_response|
+        channel_member = channel.channel_member_by_account_id(message_response['user'])
+        slack_timestamp = message_response['ts'].to_f
+        original_message = message_response['text']
+
+        Message.create!({ channel_member_id: channel_member.id, slack_timestamp:, original_message: })
+      end
+    end
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -19,4 +19,11 @@ class Message < ApplicationRecord
                          joins(:sentiment_score)
                            .where('sentiment_scores.neutral > sentiment_scores.negative
                                    and sentiment_scores.neutral > sentiment_scores.positive') }
+  scope :channel_messages, ->(channel) { where(channel_member_id: channel.channel_member_ids) }
+
+  class << self
+    def latest_slack_timestamp
+      maximum(:slack_timestamp)
+    end
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -26,4 +26,8 @@ class Message < ApplicationRecord
       maximum(:slack_timestamp)
     end
   end
+
+  def escape_original_message
+    Slack::Messages::Formatting.unescape(original_message)
+  end
 end

--- a/app/models/slack_channel.rb
+++ b/app/models/slack_channel.rb
@@ -5,6 +5,7 @@ class SlackChannel < ApplicationRecord
 
   has_many :channel_members, dependent: :destroy
   has_many :accounts, through: :channel_members, source: :slack_account
+  has_many :channel_members_with_account, -> { includes(:slack_account) }, class_name: 'ChannelMember'
 
   validates :channel_id, presence: true, uniqueness: true
   validates :name, presence: true, uniqueness: true
@@ -46,5 +47,9 @@ class SlackChannel < ApplicationRecord
       member = SlackAccount.create_account(attr)
       accounts << member unless accounts.exists?(member.id)
     end
+  end
+
+  def channel_member_by_account_id(account_id)
+    channel_members_with_account.to_ary.find { |channel_member| channel_member.slack_account.account_id == account_id }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,4 +22,9 @@ class User < ApplicationRecord
         result
       end
   end
+
+  def observed_members_messages
+    channel_member_ids = observed_members.pluck(:channel_member_id)
+    Message.all.where(channel_member_id: channel_member_ids)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,8 +23,12 @@ class User < ApplicationRecord
       end
   end
 
-  def observed_members_messages
-    channel_member_ids = observed_members.pluck(:channel_member_id)
-    Message.all.where(channel_member_id: channel_member_ids)
+  def observed_members_messages(observed_member_ids = nil)
+    ids = if observed_member_ids.nil?
+            channel_member_ids
+          else
+            observed_members.where(id: observed_member_ids).pluck(:channel_member_id)
+          end
+    Message.all.where(channel_member_id: ids)
   end
 end

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -8,7 +8,7 @@
       <span class="text-gray-400 text-sm mr-2">#<%= message.channel_member.slack_channel.name %></span>
       <span class="text-sm"><%= l Time.zone.at(message.slack_timestamp), format: :long %></span>
     </div>
-    <span class="text-gray-700 break-all"><%= message.original_message %></span>
+    <span class="text-gray-700 break-all"><%= simple_format message.escape_original_message %></span>
   </div>
 
   <div class="col-span-1 border-l-4">

--- a/app/views/messages/_reload.html.erb
+++ b/app/views/messages/_reload.html.erb
@@ -1,0 +1,4 @@
+<%= link_to 'メッセージ再読み込み',
+    reload_messages_path,
+    class: 'px-3 py-2 h-6 mr-4 bg-blue-500 text-xs text-white rounded-full hover:bg-blue-600 focus:outline-none focus:ring focus:ring-blue-300'
+%>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -6,15 +6,20 @@
         </div>
         <%= render partial: 'search_bar' %>
       </div>
-      <% if @messages.empty? %>
-        <p class="text-center">投稿メッセージが存在しません。</p>
-      <% else %>
-        <div class="flex flex-col gap-y-3">
-          <%= render partial: 'message', collection: @messages %>
+      <%= turbo_frame_tag 'messages' do %>
+        <div class="mb-4">
+          <%= render partial: 'reload' %>
         </div>
-        <div class="flex justify-center my-8">
-          <%= paginate @messages %>
-        </div>
+        <% if @messages.empty? %>
+          <p class="text-center">投稿メッセージが存在しません。</p>
+        <% else %>
+          <div class="flex flex-col gap-y-3">
+              <%= render partial: 'message', collection: @messages %>
+          </div>
+          <div class="flex justify-center my-8">
+            <%= paginate @messages %>
+          </div>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   get 'messages', to: 'messages#index'
+  get 'reload_messages', to: 'messages#reload_messages'
   root to: 'messages#index'
   devise_for :users, only: %i[registrations sessions], controllers: { registrations: 'users/registrations' }
 

--- a/lib/slack_client.rb
+++ b/lib/slack_client.rb
@@ -14,8 +14,10 @@ class SlackClient
     member_ids_response.map { |id| fetch_account(id) }
   end
 
-  def fetch_channel_members_messages(channel_id, member_ids)
-    messages_response = @client.conversations_history(channel: channel_id)
+  def fetch_channel_members_messages(channel_id, member_ids, from: nil, to: nil)
+    options = { oldest: from, latest: to }.compact
+
+    messages_response = @client.conversations_history(channel: channel_id, **options)
     messages_response['messages'].filter do |message_response|
       message_response['type'] == 'message' \
         && message_response['subtype'].nil? \

--- a/lib/slack_client.rb
+++ b/lib/slack_client.rb
@@ -14,6 +14,15 @@ class SlackClient
     member_ids_response.map { |id| fetch_account(id) }
   end
 
+  def fetch_channel_members_messages(channel_id, member_ids)
+    messages_response = @client.conversations_history(channel: channel_id)
+    messages_response['messages'].filter do |message_response|
+      message_response['type'] == 'message' \
+        && message_response['subtype'].nil? \
+        && member_ids.include?(message_response['user'])
+    end
+  end
+
   def fetch_member_ids(channel_id)
     @client.conversations_members(channel: channel_id)['members']
   end


### PR DESCRIPTION
## 概要
メッセージ一覧画面に検索機能を追加しました。

### 関連Issue
close #33 

## 動作確認方法
### 前準備
1. 環境変数`SLACK_API_TOKEN`に動作確認用のワークスペースのトークンを設定する
1. `bundle install`を実行する
1. `yarn install`を実行する
1. `bin/rails db:reset`を実行する
1. `bin/dev`を実行する
1. `/users/sign_in`にアクセスする
1. 以下の項目を入力し、ログインする
   - Eメール：`test@example.com`
   - パスワード：`testtest`
1. 設定画面`/users/edit`にアクセスする
1. チャンネル一覧の`#wata分報`にチェックを入れる
1. 監視対象ユーザー一覧の`wata00913`の監視対象をONにする
1. 「更新」ボタンをクリックする


### Slackメッセージの取得の確認
1. メッセージ一覧画面`/messages`にアクセスする
1. メッセージが0件であることを確認する
1. 「メッセージ再読み込み」ボタンをクリックする
1. Slackチャンネル`wata分報`にユーザー`wata00913`が投稿したメッセージが表示されることを確認する
1. 再度「メッセージ再読み込み」ボタンをクリックする
1. 表示されるメッセージ件数が手順4.の場合と一致することを確認する


## スクリーンショット
- Slackの投稿メッセージ（一部抜粋）
![image](https://github.com/wata00913/okimotiBot/assets/85052152/adabe721-dede-450c-8461-f563e5ba62ad)

- Slackのメッセージ取得
![Kapture 2023-09-21 at 10 57 11](https://github.com/wata00913/okimotiBot/assets/85052152/82687f65-b2c5-4e78-b38c-b9a982d19277)
