### PR TITLE
Slackメッセージ取得ボタンのレイアウト修正

### DIFF
--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -4,4 +4,9 @@ module MessagesHelper
   def unanalyzed_messages_num
     Message.unanalyzed.size
   end
+
+  def latest_message_time(messages)
+    timestamp = Message.latest_slack_timestamp(messages)
+    timestamp.nil? ? '' : l(Time.zone.at(timestamp), format: :long)
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -27,8 +27,8 @@ class Message < ApplicationRecord
   scope :analysis_target, -> { unanalyzed.order(slack_timestamp: :desc).take(MAX_ANALYSES) }
 
   class << self
-    def latest_slack_timestamp
-      maximum(:slack_timestamp)
+    def latest_slack_timestamp(messages = nil)
+      messages.nil? ? maximum(:slack_timestamp) : messages.maximum(:slack_timestamp)
     end
 
     def build_messages(messages)

--- a/app/views/messages/_message_sentiment_analysis.html.erb
+++ b/app/views/messages/_message_sentiment_analysis.html.erb
@@ -1,9 +1,7 @@
-<div class="flex flex-col w-1/2 gap-y-2">
-  <%= link_to '感情解析の開始',
-      create_sentiment_analysis_path,
-      class: 'flex items-center justify-center w-full px-3 py-4 h-6 bg-blue-500 text-lg text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring focus:ring-blue-300'
-  %>
-  <div class="flex justify-center">
-    <p>未解析のメッセージ数：<%= unanalyzed_messages_num %> </p>
-  </div>
+<%= link_to '感情解析の開始',
+    create_sentiment_analysis_path,
+    class: 'flex items-center justify-center w-full px-3 py-4 h-6 bg-blue-500 text-lg text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring focus:ring-blue-300'
+%>
+<div class="flex justify-center">
+  <p>未解析のメッセージ数：<%= unanalyzed_messages_num %> </p>
 </div>

--- a/app/views/messages/_reload.html.erb
+++ b/app/views/messages/_reload.html.erb
@@ -1,4 +1,4 @@
-<%= link_to 'メッセージ再読み込み',
+<%= link_to 'メッセージの取得',
     reload_messages_path,
-    class: 'px-3 py-2 h-6 mr-4 bg-blue-500 text-xs text-white rounded-full hover:bg-blue-600 focus:outline-none focus:ring focus:ring-blue-300'
+    class: 'flex items-center justify-center w-full px-3 py-4 h-6 mr-4 bg-blue-500 text-lg text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring focus:ring-blue-300'
 %>

--- a/app/views/messages/_reload.html.erb
+++ b/app/views/messages/_reload.html.erb
@@ -3,6 +3,10 @@
     class: 'flex items-center justify-center w-full px-3 py-4 h-6 mr-4 bg-blue-500 text-lg text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring focus:ring-blue-300'
 %>
 <div class="flex flex-col items-center">
-  <p>最新のメッセージ投稿日時</p>
-  <p><%= latest_message_time(@messages) %> </p>
+  <% if @messages.empty? %>
+    <p>未取得</p>
+  <% else %>
+    <p>最終取得日時</p>
+    <p><%= latest_message_time(@messages) %> </p>
+  <% end %>
 </div>

--- a/app/views/messages/_reload.html.erb
+++ b/app/views/messages/_reload.html.erb
@@ -2,3 +2,7 @@
     reload_messages_path,
     class: 'flex items-center justify-center w-full px-3 py-4 h-6 mr-4 bg-blue-500 text-lg text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring focus:ring-blue-300'
 %>
+<div class="flex flex-col items-center">
+  <p>最新のメッセージ投稿日時</p>
+  <p><%= latest_message_time(@messages) %> </p>
+</div>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -2,7 +2,12 @@
   <div class="bg-gray-100">
     <div class="container mx-auto px-3 py-3">
       <div class="mb-4 flex">
-        <%= render partial: 'message_sentiment_analysis' %>
+        <div class="flex flex-col w-1/2 gap-y-2">
+          <%= render partial: 'reload' %>
+        </div>
+        <div class="flex flex-col w-1/2 gap-y-2">
+          <%= render partial: 'message_sentiment_analysis' %>
+        </div>
       </div>
       <div class="mb-4 mx-1  border border-gray-400 rounded-lg">
         <div class="px-3 bg-blue-400 rounded-t-lg">
@@ -11,9 +16,6 @@
         <%= render partial: 'search_bar' %>
       </div>
       <%= turbo_frame_tag 'messages' do %>
-        <div class="mb-4">
-          <%= render partial: 'reload' %>
-        </div>
         <% if @messages.empty? %>
           <p class="text-center">投稿メッセージが存在しません。</p>
         <% else %>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag 'messages_index' do %>
   <div class="bg-gray-100">
     <div class="container mx-auto px-3 py-3">
-      <div class="mb-4 flex">
+      <div class="mb-4 flex gap-x-3">
         <div class="flex flex-col w-1/2 gap-y-2">
           <%= render partial: 'reload' %>
         </div>


### PR DESCRIPTION
## 概要
- 「Slackメッセージの取得」ボタンのレイアウトを変更しました。
- ボタンの下にメッセージの最新投稿日時を表示するようにしました。

## スクリーンショット
![image](https://github.com/wata00913/okimotiBot/assets/85052152/ad91c01c-f70a-41d9-ae59-73ec010c1b8b)
